### PR TITLE
fix: Render ビルドで devDependencies をインストールするよう修正

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -5,7 +5,7 @@ services:
     plan: free
     branch: main
     healthCheckPath: /
-    buildCommand: npm install && npm run build
+    buildCommand: npm install --include=dev && npm run build
     startCommand: node build
     envVars:
       - key: DATABASE_URL


### PR DESCRIPTION
## Summary
- Render デプロイ時に `NODE_ENV=production` が設定されているため、`npm install` が devDependencies（vite, svelte-kit 等）をスキップしビルドが失敗していた
- `buildCommand` に `--include=dev` を追加し、ビルドに必要な devDependencies がインストールされるよう修正

## Test plan
- [ ] Render にデプロイしてビルドが成功することを確認
- [ ] アプリケーションが正常に起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)