### PR TITLE
fix: Render PostgreSQL 自己署名証明書エラーを修正

### DIFF
--- a/src/lib/server/db/postgres.ts
+++ b/src/lib/server/db/postgres.ts
@@ -10,7 +10,7 @@ export async function createPostgresClient(connectionString: string): Promise<Db
 			max: 10,
 			idleTimeoutMillis: 30_000,
 			connectionTimeoutMillis: 5_000,
-			ssl: process.env.NODE_ENV === 'production' ? true : false
+			ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false
 		});
 
 		pool.on('error', (err) => {


### PR DESCRIPTION
## Summary
- Render の PostgreSQL は自己署名証明書を使用するため、`ssl: true` では接続が拒否される
- `ssl: { rejectUnauthorized: false }` に変更し、接続できるよう修正

## Test plan
- [ ] Render にデプロイして 500 エラーが解消されることを確認
- [ ] チャットルームの作成・参加が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)