### PR TITLE
feat: Ctrl+Enter送信とニコニコ風改行表示対応

### DIFF
--- a/src/lib/components/ChatInput.svelte
+++ b/src/lib/components/ChatInput.svelte
@@ -7,6 +7,7 @@
 	let content = $state('');
 	let showEmojiPicker = $state(false);
 	let inputEl: HTMLTextAreaElement;
+	const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.userAgent);
 
 	const EMOJI_CATEGORIES = [
 		{ name: '顔', emojis: ['😀','😂','🥹','😍','🤔','😎','😢','😤','🥳','😱','🤣','😊','🥰','😏','🤗','😴','🤮','😈','👻','💀'] },
@@ -76,7 +77,7 @@
 				bind:this={inputEl}
 				bind:value={content}
 				onkeydown={handleKeydown}
-				placeholder="メッセージを入力... (Ctrl+Enterで送信)"
+				placeholder={`メッセージを入力... (${isMac ? 'Cmd' : 'Ctrl'}+Enterで送信)`}
 				rows="1"
 				class="w-full px-4 py-2.5 pr-11 border border-gray-300 rounded-2xl resize-none text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent max-h-32"
 			></textarea>

--- a/src/lib/components/chat/NiconicoView.svelte
+++ b/src/lib/components/chat/NiconicoView.svelte
@@ -48,11 +48,14 @@
 
 		const el = document.createElement('div');
 		el.className = 'niconico-comment';
-		const displayContent = msg.content.split('\n').slice(0, 3).join('\n');
+		const lines = msg.content.split('\n');
+		const displayContent = lines.slice(0, 3).join('\n') + (lines.length > 3 ? '...' : '');
 		el.textContent = `${msg.nickname}: ${displayContent}`;
 
-		// Random vertical position (5% - 85%)
-		const top = 5 + Math.random() * 80;
+		// Random vertical position — adjust upper bound for multi-line comments
+		const lineCount = Math.min(lines.length, 3);
+		const maxTop = 85 - (lineCount - 1) * 8;
+		const top = 5 + Math.random() * Math.max(maxTop - 5, 10);
 		el.style.top = `${top}%`;
 
 		// Random duration (5-8 seconds)


### PR DESCRIPTION
## Summary
- メッセージ送信をEnterからCtrl+Enter（Mac: Cmd+Enter）に変更し、通常のEnterで改行可能に
- ニコニコ風表示で改行を反映（`white-space: pre-line`）、最大3行制限・省略記号付き
- placeholderをプラットフォーム判定でCmd/Ctrl表示を出し分け

## Test plan
- [ ] テキストエリアでEnterキーを押して改行されることを確認
- [ ] Cmd+Enter（Mac）/ Ctrl+Enter（Windows）で送信されることを確認
- [ ] ニコニコ風表示で改行付きメッセージが複数行で流れることを確認
- [ ] 4行以上のメッセージが3行+「...」で表示されることを確認
- [ ] 複数行コメントが画面下部にはみ出さないことを確認
- [ ] モバイルで送信ボタンから送信できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)