### PR TITLE
fix: ニコニコ風コメントの意図しない改行表示を修正

### DIFF
--- a/src/lib/components/chat/NiconicoView.svelte
+++ b/src/lib/components/chat/NiconicoView.svelte
@@ -98,7 +98,7 @@
 	:global(.niconico-comment) {
 		position: absolute;
 		left: 100%;
-		white-space: pre-line;
+		white-space: pre;
 		font-size: 1.25rem;
 		font-weight: bold;
 		color: white;


### PR DESCRIPTION
## Summary
- ニコニコ風コメントの `white-space` を `pre-line` から `pre` に変更
- `pre-line` はコンテナ幅での自動折り返しを行うため、`left: 100%` で配置されたコメントが意図しない改行を表示していた
- `pre` に変更し、明示的な改行（`\n`）のみ表示するように修正

## Test plan
- [ ] ニコニコ風表示で改行を含まないメッセージが1行で流れることを確認
- [ ] 改行を含むメッセージ（Ctrl+Enter）が正しく複数行で表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)