### PR TITLE
feat: 期限切れルーム・チャットをアーカイブテーブルに保存

### DIFF
--- a/src/lib/server/db/migrate.ts
+++ b/src/lib/server/db/migrate.ts
@@ -58,6 +58,42 @@ const migrations: { name: string; statements: string[] }[] = [
 		statements: [
 			`ALTER TABLE rooms ALTER COLUMN invite_code TYPE VARCHAR(12)`
 		]
+	},
+	{
+		name: '003_archive_tables.sql',
+		statements: [
+			`CREATE TABLE IF NOT EXISTS archived_rooms (
+  id UUID PRIMARY KEY,
+  name VARCHAR(100) NOT NULL,
+  invite_code VARCHAR(12) NOT NULL,
+  creator_id UUID NOT NULL,
+  created_at TIMESTAMPTZ,
+  is_active BOOLEAN,
+  archived_at TIMESTAMPTZ DEFAULT NOW()
+)`,
+			`CREATE INDEX IF NOT EXISTS idx_archived_rooms_creator ON archived_rooms(creator_id)`,
+			`CREATE INDEX IF NOT EXISTS idx_archived_rooms_archived_at ON archived_rooms(archived_at)`,
+			`CREATE TABLE IF NOT EXISTS archived_participants (
+  id UUID PRIMARY KEY,
+  room_id UUID NOT NULL,
+  nickname VARCHAR(50) NOT NULL,
+  joined_at TIMESTAMPTZ,
+  last_seen_at TIMESTAMPTZ,
+  archived_at TIMESTAMPTZ DEFAULT NOW()
+)`,
+			`CREATE INDEX IF NOT EXISTS idx_archived_participants_room_id ON archived_participants(room_id)`,
+			`CREATE TABLE IF NOT EXISTS archived_messages (
+  id UUID PRIMARY KEY,
+  room_id UUID NOT NULL,
+  participant_id UUID NOT NULL,
+  nickname VARCHAR(50) NOT NULL,
+  content TEXT NOT NULL,
+  created_at TIMESTAMPTZ,
+  archived_at TIMESTAMPTZ DEFAULT NOW()
+)`,
+			`CREATE INDEX IF NOT EXISTS idx_archived_messages_room_id ON archived_messages(room_id)`,
+			`CREATE INDEX IF NOT EXISTS idx_archived_messages_archived_at ON archived_messages(archived_at)`
+		]
 	}
 ];
 

--- a/src/lib/server/db/migrate.ts
+++ b/src/lib/server/db/migrate.ts
@@ -74,7 +74,6 @@ const migrations: { name: string; statements: string[] }[] = [
 )`,
 			`CREATE INDEX IF NOT EXISTS idx_archived_rooms_creator ON archived_rooms(creator_id)`,
 			`CREATE INDEX IF NOT EXISTS idx_archived_rooms_archived_at ON archived_rooms(archived_at)`,
-			`CREATE INDEX IF NOT EXISTS idx_archived_rooms_invite_code ON archived_rooms(invite_code)`,
 			`CREATE TABLE IF NOT EXISTS archived_participants (
   id UUID PRIMARY KEY,
   room_id UUID NOT NULL,
@@ -95,6 +94,7 @@ const migrations: { name: string; statements: string[] }[] = [
   archived_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 )`,
 			`CREATE INDEX IF NOT EXISTS idx_archived_messages_room_id ON archived_messages(room_id)`,
+			`CREATE INDEX IF NOT EXISTS idx_archived_messages_participant_id ON archived_messages(participant_id)`,
 			`CREATE INDEX IF NOT EXISTS idx_archived_messages_archived_at ON archived_messages(archived_at)`
 		]
 	}

--- a/src/lib/server/db/migrate.ts
+++ b/src/lib/server/db/migrate.ts
@@ -74,6 +74,7 @@ const migrations: { name: string; statements: string[] }[] = [
 )`,
 			`CREATE INDEX IF NOT EXISTS idx_archived_rooms_creator ON archived_rooms(creator_id)`,
 			`CREATE INDEX IF NOT EXISTS idx_archived_rooms_archived_at ON archived_rooms(archived_at)`,
+			`CREATE INDEX IF NOT EXISTS idx_archived_rooms_invite_code ON archived_rooms(invite_code)`,
 			`CREATE TABLE IF NOT EXISTS archived_participants (
   id UUID PRIMARY KEY,
   room_id UUID NOT NULL,

--- a/src/lib/server/db/migrate.ts
+++ b/src/lib/server/db/migrate.ts
@@ -67,9 +67,10 @@ const migrations: { name: string; statements: string[] }[] = [
   name VARCHAR(100) NOT NULL,
   invite_code VARCHAR(12) NOT NULL,
   creator_id UUID NOT NULL,
-  created_at TIMESTAMPTZ,
-  is_active BOOLEAN,
-  archived_at TIMESTAMPTZ DEFAULT NOW()
+  creator_email VARCHAR(255) NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL,
+  is_active BOOLEAN NOT NULL,
+  archived_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 )`,
 			`CREATE INDEX IF NOT EXISTS idx_archived_rooms_creator ON archived_rooms(creator_id)`,
 			`CREATE INDEX IF NOT EXISTS idx_archived_rooms_archived_at ON archived_rooms(archived_at)`,
@@ -77,19 +78,20 @@ const migrations: { name: string; statements: string[] }[] = [
   id UUID PRIMARY KEY,
   room_id UUID NOT NULL,
   nickname VARCHAR(50) NOT NULL,
-  joined_at TIMESTAMPTZ,
-  last_seen_at TIMESTAMPTZ,
-  archived_at TIMESTAMPTZ DEFAULT NOW()
+  joined_at TIMESTAMPTZ NOT NULL,
+  last_seen_at TIMESTAMPTZ NOT NULL,
+  archived_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 )`,
 			`CREATE INDEX IF NOT EXISTS idx_archived_participants_room_id ON archived_participants(room_id)`,
+			`CREATE INDEX IF NOT EXISTS idx_archived_participants_archived_at ON archived_participants(archived_at)`,
 			`CREATE TABLE IF NOT EXISTS archived_messages (
   id UUID PRIMARY KEY,
   room_id UUID NOT NULL,
   participant_id UUID NOT NULL,
   nickname VARCHAR(50) NOT NULL,
   content TEXT NOT NULL,
-  created_at TIMESTAMPTZ,
-  archived_at TIMESTAMPTZ DEFAULT NOW()
+  created_at TIMESTAMPTZ NOT NULL,
+  archived_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 )`,
 			`CREATE INDEX IF NOT EXISTS idx_archived_messages_room_id ON archived_messages(room_id)`,
 			`CREATE INDEX IF NOT EXISTS idx_archived_messages_archived_at ON archived_messages(archived_at)`

--- a/src/lib/server/db/migrations/003_archive_tables.sql
+++ b/src/lib/server/db/migrations/003_archive_tables.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS archived_rooms (
+  id UUID PRIMARY KEY,
+  name VARCHAR(100) NOT NULL,
+  invite_code VARCHAR(12) NOT NULL,
+  creator_id UUID NOT NULL,
+  created_at TIMESTAMPTZ,
+  is_active BOOLEAN,
+  archived_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_archived_rooms_creator ON archived_rooms(creator_id);
+CREATE INDEX IF NOT EXISTS idx_archived_rooms_archived_at ON archived_rooms(archived_at);
+
+CREATE TABLE IF NOT EXISTS archived_participants (
+  id UUID PRIMARY KEY,
+  room_id UUID NOT NULL,
+  nickname VARCHAR(50) NOT NULL,
+  joined_at TIMESTAMPTZ,
+  last_seen_at TIMESTAMPTZ,
+  archived_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_archived_participants_room_id ON archived_participants(room_id);
+
+CREATE TABLE IF NOT EXISTS archived_messages (
+  id UUID PRIMARY KEY,
+  room_id UUID NOT NULL,
+  participant_id UUID NOT NULL,
+  nickname VARCHAR(50) NOT NULL,
+  content TEXT NOT NULL,
+  created_at TIMESTAMPTZ,
+  archived_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_archived_messages_room_id ON archived_messages(room_id);
+CREATE INDEX IF NOT EXISTS idx_archived_messages_archived_at ON archived_messages(archived_at);

--- a/src/lib/server/db/migrations/003_archive_tables.sql
+++ b/src/lib/server/db/migrations/003_archive_tables.sql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS archived_rooms (
 );
 CREATE INDEX IF NOT EXISTS idx_archived_rooms_creator ON archived_rooms(creator_id);
 CREATE INDEX IF NOT EXISTS idx_archived_rooms_archived_at ON archived_rooms(archived_at);
+CREATE INDEX IF NOT EXISTS idx_archived_rooms_invite_code ON archived_rooms(invite_code);
 
 CREATE TABLE IF NOT EXISTS archived_participants (
   id UUID PRIMARY KEY,

--- a/src/lib/server/db/migrations/003_archive_tables.sql
+++ b/src/lib/server/db/migrations/003_archive_tables.sql
@@ -10,7 +10,6 @@ CREATE TABLE IF NOT EXISTS archived_rooms (
 );
 CREATE INDEX IF NOT EXISTS idx_archived_rooms_creator ON archived_rooms(creator_id);
 CREATE INDEX IF NOT EXISTS idx_archived_rooms_archived_at ON archived_rooms(archived_at);
-CREATE INDEX IF NOT EXISTS idx_archived_rooms_invite_code ON archived_rooms(invite_code);
 
 CREATE TABLE IF NOT EXISTS archived_participants (
   id UUID PRIMARY KEY,
@@ -33,4 +32,5 @@ CREATE TABLE IF NOT EXISTS archived_messages (
   archived_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 CREATE INDEX IF NOT EXISTS idx_archived_messages_room_id ON archived_messages(room_id);
+CREATE INDEX IF NOT EXISTS idx_archived_messages_participant_id ON archived_messages(participant_id);
 CREATE INDEX IF NOT EXISTS idx_archived_messages_archived_at ON archived_messages(archived_at);

--- a/src/lib/server/db/migrations/003_archive_tables.sql
+++ b/src/lib/server/db/migrations/003_archive_tables.sql
@@ -3,9 +3,10 @@ CREATE TABLE IF NOT EXISTS archived_rooms (
   name VARCHAR(100) NOT NULL,
   invite_code VARCHAR(12) NOT NULL,
   creator_id UUID NOT NULL,
-  created_at TIMESTAMPTZ,
-  is_active BOOLEAN,
-  archived_at TIMESTAMPTZ DEFAULT NOW()
+  creator_email VARCHAR(255) NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL,
+  is_active BOOLEAN NOT NULL,
+  archived_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 CREATE INDEX IF NOT EXISTS idx_archived_rooms_creator ON archived_rooms(creator_id);
 CREATE INDEX IF NOT EXISTS idx_archived_rooms_archived_at ON archived_rooms(archived_at);
@@ -14,11 +15,12 @@ CREATE TABLE IF NOT EXISTS archived_participants (
   id UUID PRIMARY KEY,
   room_id UUID NOT NULL,
   nickname VARCHAR(50) NOT NULL,
-  joined_at TIMESTAMPTZ,
-  last_seen_at TIMESTAMPTZ,
-  archived_at TIMESTAMPTZ DEFAULT NOW()
+  joined_at TIMESTAMPTZ NOT NULL,
+  last_seen_at TIMESTAMPTZ NOT NULL,
+  archived_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 CREATE INDEX IF NOT EXISTS idx_archived_participants_room_id ON archived_participants(room_id);
+CREATE INDEX IF NOT EXISTS idx_archived_participants_archived_at ON archived_participants(archived_at);
 
 CREATE TABLE IF NOT EXISTS archived_messages (
   id UUID PRIMARY KEY,
@@ -26,8 +28,8 @@ CREATE TABLE IF NOT EXISTS archived_messages (
   participant_id UUID NOT NULL,
   nickname VARCHAR(50) NOT NULL,
   content TEXT NOT NULL,
-  created_at TIMESTAMPTZ,
-  archived_at TIMESTAMPTZ DEFAULT NOW()
+  created_at TIMESTAMPTZ NOT NULL,
+  archived_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 CREATE INDEX IF NOT EXISTS idx_archived_messages_room_id ON archived_messages(room_id);
 CREATE INDEX IF NOT EXISTS idx_archived_messages_archived_at ON archived_messages(archived_at);

--- a/src/lib/server/repositories/room.ts
+++ b/src/lib/server/repositories/room.ts
@@ -93,7 +93,7 @@ export async function deleteRoom(roomId: string): Promise<void> {
 		     (id, name, invite_code, creator_id, creator_email, created_at, is_active, archived_at)
 		   -- COALESCE handles the rare case where the creator account was deleted
 		   SELECT r.id, r.name, r.invite_code, r.creator_id, COALESCE(u.email, ''),
-		          r.created_at, r.is_active, NOW()
+		          COALESCE(r.created_at, NOW()), r.is_active, NOW()
 		   FROM rooms r
 		   LEFT JOIN users u ON u.id = r.creator_id
 		   WHERE r.id = $1
@@ -141,7 +141,7 @@ export async function deleteExpiredRooms(): Promise<string[]> {
 		     (id, name, invite_code, creator_id, creator_email, created_at, is_active, archived_at)
 		   -- COALESCE handles the rare case where the creator account was deleted
 		   SELECT r.id, r.name, r.invite_code, r.creator_id, COALESCE(u.email, ''),
-		          r.created_at, r.is_active, NOW()
+		          COALESCE(r.created_at, NOW()), r.is_active, NOW()
 		   FROM rooms r
 		   LEFT JOIN users u ON u.id = r.creator_id
 		   WHERE r.id IN (SELECT id FROM expired)

--- a/src/lib/server/repositories/room.ts
+++ b/src/lib/server/repositories/room.ts
@@ -2,8 +2,13 @@ import { getDb } from '$lib/server/db/index.js';
 import { generateInviteCode } from '$lib/utils/invite-code.js';
 import type { Room } from '$lib/types/index.js';
 
-/** Duration after which a room is considered expired and eligible for deletion. */
-const ROOM_EXPIRY_INTERVAL = '6 hours';
+/**
+ * Hours after creation at which a room expires and is eligible for deletion.
+ * NOTE: This constant is for TypeScript use only. The SQL queries below contain
+ * the matching literal `INTERVAL '6 hours'` — if you change this value, update
+ * those SQL literals too, as well as `getRemainingTime` in utils/remaining-time.ts.
+ */
+export const ROOM_EXPIRY_HOURS = 6;
 
 interface RoomRow {
 	id: string;
@@ -79,10 +84,11 @@ export async function getRoomByInviteCode(inviteCode: string): Promise<Room | nu
 }
 
 /**
- * Archive then hard-delete a single room.
- * Uses a single CTE so the archive and delete are atomic.
- * On concurrent calls for the same room, the archive INSERT is idempotent
- * (preserves the original archived_at timestamp).
+ * Archive then hard-delete a single room atomically using a CTE.
+ * If the room does not exist, all CTEs produce zero rows and the DELETE is a no-op;
+ * the caller is responsible for verifying room ownership before calling this function.
+ * On concurrent calls for the same room, archive INSERTs are idempotent (DO NOTHING)
+ * because the CTE guarantees the archival runs once within a single atomic statement.
  */
 export async function deleteRoom(roomId: string): Promise<void> {
 	const db = await getDb();
@@ -96,7 +102,7 @@ export async function deleteRoom(roomId: string): Promise<void> {
 		   FROM rooms r
 		   JOIN users u ON u.id = r.creator_id
 		   WHERE r.id = $1
-		   ON CONFLICT (id) DO UPDATE SET archived_at = archived_rooms.archived_at
+		   ON CONFLICT (id) DO NOTHING
 		 ),
 		 archive_participants AS (
 		   INSERT INTO archived_participants
@@ -104,7 +110,7 @@ export async function deleteRoom(roomId: string): Promise<void> {
 		   SELECT id, room_id, nickname, joined_at, last_seen_at, NOW()
 		   FROM participants
 		   WHERE room_id = $1
-		   ON CONFLICT (id) DO UPDATE SET archived_at = archived_participants.archived_at
+		   ON CONFLICT (id) DO NOTHING
 		 ),
 		 archive_messages AS (
 		   INSERT INTO archived_messages
@@ -113,7 +119,7 @@ export async function deleteRoom(roomId: string): Promise<void> {
 		   FROM messages m
 		   JOIN participants p ON p.id = m.participant_id
 		   WHERE m.room_id = $1
-		   ON CONFLICT (id) DO UPDATE SET archived_at = archived_messages.archived_at
+		   ON CONFLICT (id) DO NOTHING
 		 )
 		 DELETE FROM rooms WHERE id = $1`,
 		[roomId]
@@ -121,9 +127,11 @@ export async function deleteRoom(roomId: string): Promise<void> {
 }
 
 /**
- * Archive then hard-delete all rooms older than ROOM_EXPIRY_INTERVAL.
+ * Archive then hard-delete all rooms older than 6 hours (see ROOM_EXPIRY_HOURS).
  * Uses a single CTE so the archive and delete are atomic — no TOCTOU window.
- * On concurrent calls, archive INSERTs are idempotent (preserve original timestamps).
+ * On concurrent calls the archive INSERTs are idempotent (DO NOTHING) because
+ * each CTE is a single atomic statement; the second concurrent DELETE simply
+ * finds no matching rows and returns an empty result.
  * Returns the IDs of deleted rooms.
  */
 export async function deleteExpiredRooms(): Promise<string[]> {
@@ -131,7 +139,7 @@ export async function deleteExpiredRooms(): Promise<string[]> {
 
 	const result = await db.query<{ id: string }>(
 		`WITH expired AS (
-		   SELECT id FROM rooms WHERE created_at < NOW() - INTERVAL '${ROOM_EXPIRY_INTERVAL}'
+		   SELECT id FROM rooms WHERE created_at < NOW() - INTERVAL '6 hours'
 		 ),
 		 archive_rooms AS (
 		   INSERT INTO archived_rooms
@@ -141,7 +149,7 @@ export async function deleteExpiredRooms(): Promise<string[]> {
 		   FROM rooms r
 		   JOIN users u ON u.id = r.creator_id
 		   WHERE r.id IN (SELECT id FROM expired)
-		   ON CONFLICT (id) DO UPDATE SET archived_at = archived_rooms.archived_at
+		   ON CONFLICT (id) DO NOTHING
 		 ),
 		 archive_participants AS (
 		   INSERT INTO archived_participants
@@ -149,7 +157,7 @@ export async function deleteExpiredRooms(): Promise<string[]> {
 		   SELECT id, room_id, nickname, joined_at, last_seen_at, NOW()
 		   FROM participants
 		   WHERE room_id IN (SELECT id FROM expired)
-		   ON CONFLICT (id) DO UPDATE SET archived_at = archived_participants.archived_at
+		   ON CONFLICT (id) DO NOTHING
 		 ),
 		 archive_messages AS (
 		   INSERT INTO archived_messages
@@ -158,7 +166,7 @@ export async function deleteExpiredRooms(): Promise<string[]> {
 		   FROM messages m
 		   JOIN participants p ON p.id = m.participant_id
 		   WHERE m.room_id IN (SELECT id FROM expired)
-		   ON CONFLICT (id) DO UPDATE SET archived_at = archived_messages.archived_at
+		   ON CONFLICT (id) DO NOTHING
 		 )
 		 DELETE FROM rooms WHERE id IN (SELECT id FROM expired)
 		 RETURNING id`
@@ -172,7 +180,7 @@ export async function countActiveRoomsByCreator(creatorId: string): Promise<numb
 	const result = await db.query<{ count: string }>(
 		`SELECT count(*)::text as count FROM rooms
 		 WHERE creator_id = $1 AND is_active = TRUE
-		 AND created_at > NOW() - INTERVAL '${ROOM_EXPIRY_INTERVAL}'`,
+		 AND created_at > NOW() - INTERVAL '6 hours'`,
 		[creatorId]
 	);
 	return parseInt(result.rows[0]?.count ?? '0', 10);

--- a/src/lib/server/repositories/room.ts
+++ b/src/lib/server/repositories/room.ts
@@ -7,7 +7,7 @@ interface RoomRow {
 	name: string;
 	invite_code: string;
 	creator_id: string;
-	created_at: Date;
+	created_at: string | Date;
 	is_active: boolean;
 }
 
@@ -38,8 +38,9 @@ export async function createRoom(name: string, creatorId: string): Promise<Room>
 			return toRoom(result.rows[0]);
 		} catch (e: unknown) {
 			const isUniqueViolation =
-				e instanceof Error && ('code' in e) && (e as { code: string }).code === '23505';
-			if (!isUniqueViolation || attempt === 2) throw e;
+				e instanceof Error && 'code' in e && (e as { code: string }).code === '23505';
+			if (!isUniqueViolation) throw e;
+			// Continue loop on invite code collision
 		}
 	}
 
@@ -74,59 +75,90 @@ export async function getRoomByInviteCode(inviteCode: string): Promise<Room | nu
 	return result.rows.length > 0 ? toRoom(result.rows[0]) : null;
 }
 
+/**
+ * Archive then hard-delete a single room.
+ * Uses a single CTE so the archive and delete are atomic.
+ */
 export async function deleteRoom(roomId: string): Promise<void> {
 	const db = await getDb();
-	await db.query(`DELETE FROM rooms WHERE id = $1`, [roomId]);
+
+	await db.query(
+		`WITH archive_rooms AS (
+		   INSERT INTO archived_rooms
+		     (id, name, invite_code, creator_id, creator_email, created_at, is_active, archived_at)
+		   SELECT r.id, r.name, r.invite_code, r.creator_id, u.email,
+		          r.created_at, r.is_active, NOW()
+		   FROM rooms r
+		   JOIN users u ON u.id = r.creator_id
+		   WHERE r.id = $1
+		   ON CONFLICT (id) DO NOTHING
+		 ),
+		 archive_participants AS (
+		   INSERT INTO archived_participants
+		     (id, room_id, nickname, joined_at, last_seen_at, archived_at)
+		   SELECT id, room_id, nickname, joined_at, last_seen_at, NOW()
+		   FROM participants
+		   WHERE room_id = $1
+		   ON CONFLICT (id) DO NOTHING
+		 ),
+		 archive_messages AS (
+		   INSERT INTO archived_messages
+		     (id, room_id, participant_id, nickname, content, created_at, archived_at)
+		   SELECT m.id, m.room_id, m.participant_id, p.nickname, m.content, m.created_at, NOW()
+		   FROM messages m
+		   JOIN participants p ON p.id = m.participant_id
+		   WHERE m.room_id = $1
+		   ON CONFLICT (id) DO NOTHING
+		 )
+		 DELETE FROM rooms WHERE id = $1`,
+		[roomId]
+	);
 }
 
+/**
+ * Archive then hard-delete all rooms older than 6 hours.
+ * Uses a single CTE so the archive and delete are atomic — no TOCTOU window.
+ * Returns the IDs of deleted rooms.
+ */
 export async function deleteExpiredRooms(): Promise<string[]> {
 	const db = await getDb();
 
-	// Find expired room IDs
-	const expired = await db.query<{ id: string }>(
-		`SELECT id FROM rooms WHERE created_at < NOW() - INTERVAL '6 hours'`
-	);
-	if (expired.rows.length === 0) return [];
-
-	const expiredIds = expired.rows.map((r) => r.id);
-	const placeholders = expiredIds.map((_, i) => `$${i + 1}`).join(', ');
-
-	// Archive rooms
-	await db.query(
-		`INSERT INTO archived_rooms (id, name, invite_code, creator_id, created_at, is_active, archived_at)
-		 SELECT id, name, invite_code, creator_id, created_at, is_active, NOW()
-		 FROM rooms WHERE id IN (${placeholders})
-		 ON CONFLICT (id) DO NOTHING`,
-		expiredIds
-	);
-
-	// Archive participants
-	await db.query(
-		`INSERT INTO archived_participants (id, room_id, nickname, joined_at, last_seen_at, archived_at)
-		 SELECT id, room_id, nickname, joined_at, last_seen_at, NOW()
-		 FROM participants WHERE room_id IN (${placeholders})
-		 ON CONFLICT (id) DO NOTHING`,
-		expiredIds
-	);
-
-	// Archive messages with nickname
-	await db.query(
-		`INSERT INTO archived_messages (id, room_id, participant_id, nickname, content, created_at, archived_at)
-		 SELECT m.id, m.room_id, m.participant_id, p.nickname, m.content, m.created_at, NOW()
-		 FROM messages m
-		 JOIN participants p ON p.id = m.participant_id
-		 WHERE m.room_id IN (${placeholders})
-		 ON CONFLICT (id) DO NOTHING`,
-		expiredIds
+	const result = await db.query<{ id: string }>(
+		`WITH expired AS (
+		   SELECT id FROM rooms WHERE created_at < NOW() - INTERVAL '6 hours'
+		 ),
+		 archive_rooms AS (
+		   INSERT INTO archived_rooms
+		     (id, name, invite_code, creator_id, creator_email, created_at, is_active, archived_at)
+		   SELECT r.id, r.name, r.invite_code, r.creator_id, u.email,
+		          r.created_at, r.is_active, NOW()
+		   FROM rooms r
+		   JOIN users u ON u.id = r.creator_id
+		   WHERE r.id IN (SELECT id FROM expired)
+		   ON CONFLICT (id) DO NOTHING
+		 ),
+		 archive_participants AS (
+		   INSERT INTO archived_participants
+		     (id, room_id, nickname, joined_at, last_seen_at, archived_at)
+		   SELECT id, room_id, nickname, joined_at, last_seen_at, NOW()
+		   FROM participants
+		   WHERE room_id IN (SELECT id FROM expired)
+		   ON CONFLICT (id) DO NOTHING
+		 ),
+		 archive_messages AS (
+		   INSERT INTO archived_messages
+		     (id, room_id, participant_id, nickname, content, created_at, archived_at)
+		   SELECT m.id, m.room_id, m.participant_id, p.nickname, m.content, m.created_at, NOW()
+		   FROM messages m
+		   JOIN participants p ON p.id = m.participant_id
+		   WHERE m.room_id IN (SELECT id FROM expired)
+		   ON CONFLICT (id) DO NOTHING
+		 )
+		 DELETE FROM rooms WHERE id IN (SELECT id FROM expired)
+		 RETURNING id`
 	);
 
-	// Delete expired rooms (cascades to participants and messages)
-	await db.query(
-		`DELETE FROM rooms WHERE id IN (${placeholders})`,
-		expiredIds
-	);
-
-	return expiredIds;
+	return result.rows.map((r) => r.id);
 }
 
 export async function countActiveRoomsByCreator(creatorId: string): Promise<number> {

--- a/src/lib/server/repositories/room.ts
+++ b/src/lib/server/repositories/room.ts
@@ -2,13 +2,6 @@ import { getDb } from '$lib/server/db/index.js';
 import { generateInviteCode } from '$lib/utils/invite-code.js';
 import type { Room } from '$lib/types/index.js';
 
-/**
- * Hours after creation at which a room expires and is eligible for deletion.
- * NOTE: This constant is for TypeScript use only. The SQL queries below contain
- * the matching literal `INTERVAL '6 hours'` — if you change this value, update
- * those SQL literals too, as well as `getRemainingTime` in utils/remaining-time.ts.
- */
-export const ROOM_EXPIRY_HOURS = 6;
 
 interface RoomRow {
 	id: string;
@@ -77,7 +70,8 @@ export async function getRoomById(roomId: string): Promise<Room | null> {
 export async function getRoomByInviteCode(inviteCode: string): Promise<Room | null> {
 	const db = await getDb();
 	const result = await db.query<RoomRow>(
-		`SELECT * FROM rooms WHERE invite_code = $1 AND is_active = TRUE`,
+		`SELECT * FROM rooms WHERE invite_code = $1 AND is_active = TRUE
+		 AND created_at > NOW() - INTERVAL '6 hours'`,
 		[inviteCode]
 	);
 	return result.rows.length > 0 ? toRoom(result.rows[0]) : null;
@@ -97,10 +91,11 @@ export async function deleteRoom(roomId: string): Promise<void> {
 		`WITH archive_rooms AS (
 		   INSERT INTO archived_rooms
 		     (id, name, invite_code, creator_id, creator_email, created_at, is_active, archived_at)
-		   SELECT r.id, r.name, r.invite_code, r.creator_id, u.email,
+		   -- COALESCE handles the rare case where the creator account was deleted
+		   SELECT r.id, r.name, r.invite_code, r.creator_id, COALESCE(u.email, ''),
 		          r.created_at, r.is_active, NOW()
 		   FROM rooms r
-		   JOIN users u ON u.id = r.creator_id
+		   LEFT JOIN users u ON u.id = r.creator_id
 		   WHERE r.id = $1
 		   ON CONFLICT (id) DO NOTHING
 		 ),
@@ -127,7 +122,7 @@ export async function deleteRoom(roomId: string): Promise<void> {
 }
 
 /**
- * Archive then hard-delete all rooms older than 6 hours (see ROOM_EXPIRY_HOURS).
+ * Archive then hard-delete all rooms older than 6 hours.
  * Uses a single CTE so the archive and delete are atomic — no TOCTOU window.
  * On concurrent calls the archive INSERTs are idempotent (DO NOTHING) because
  * each CTE is a single atomic statement; the second concurrent DELETE simply
@@ -144,10 +139,11 @@ export async function deleteExpiredRooms(): Promise<string[]> {
 		 archive_rooms AS (
 		   INSERT INTO archived_rooms
 		     (id, name, invite_code, creator_id, creator_email, created_at, is_active, archived_at)
-		   SELECT r.id, r.name, r.invite_code, r.creator_id, u.email,
+		   -- COALESCE handles the rare case where the creator account was deleted
+		   SELECT r.id, r.name, r.invite_code, r.creator_id, COALESCE(u.email, ''),
 		          r.created_at, r.is_active, NOW()
 		   FROM rooms r
-		   JOIN users u ON u.id = r.creator_id
+		   LEFT JOIN users u ON u.id = r.creator_id
 		   WHERE r.id IN (SELECT id FROM expired)
 		   ON CONFLICT (id) DO NOTHING
 		 ),

--- a/src/lib/server/repositories/room.ts
+++ b/src/lib/server/repositories/room.ts
@@ -81,11 +81,52 @@ export async function deleteRoom(roomId: string): Promise<void> {
 
 export async function deleteExpiredRooms(): Promise<string[]> {
 	const db = await getDb();
-	const result = await db.query<{ id: string }>(
-		`DELETE FROM rooms WHERE created_at < NOW() - INTERVAL '6 hours'
-		 RETURNING id`
+
+	// Find expired room IDs
+	const expired = await db.query<{ id: string }>(
+		`SELECT id FROM rooms WHERE created_at < NOW() - INTERVAL '6 hours'`
 	);
-	return result.rows.map((r) => r.id);
+	if (expired.rows.length === 0) return [];
+
+	const expiredIds = expired.rows.map((r) => r.id);
+	const placeholders = expiredIds.map((_, i) => `$${i + 1}`).join(', ');
+
+	// Archive rooms
+	await db.query(
+		`INSERT INTO archived_rooms (id, name, invite_code, creator_id, created_at, is_active, archived_at)
+		 SELECT id, name, invite_code, creator_id, created_at, is_active, NOW()
+		 FROM rooms WHERE id IN (${placeholders})
+		 ON CONFLICT (id) DO NOTHING`,
+		expiredIds
+	);
+
+	// Archive participants
+	await db.query(
+		`INSERT INTO archived_participants (id, room_id, nickname, joined_at, last_seen_at, archived_at)
+		 SELECT id, room_id, nickname, joined_at, last_seen_at, NOW()
+		 FROM participants WHERE room_id IN (${placeholders})
+		 ON CONFLICT (id) DO NOTHING`,
+		expiredIds
+	);
+
+	// Archive messages with nickname
+	await db.query(
+		`INSERT INTO archived_messages (id, room_id, participant_id, nickname, content, created_at, archived_at)
+		 SELECT m.id, m.room_id, m.participant_id, p.nickname, m.content, m.created_at, NOW()
+		 FROM messages m
+		 JOIN participants p ON p.id = m.participant_id
+		 WHERE m.room_id IN (${placeholders})
+		 ON CONFLICT (id) DO NOTHING`,
+		expiredIds
+	);
+
+	// Delete expired rooms (cascades to participants and messages)
+	await db.query(
+		`DELETE FROM rooms WHERE id IN (${placeholders})`,
+		expiredIds
+	);
+
+	return expiredIds;
 }
 
 export async function countActiveRoomsByCreator(creatorId: string): Promise<number> {

--- a/src/lib/server/repositories/room.ts
+++ b/src/lib/server/repositories/room.ts
@@ -2,6 +2,9 @@ import { getDb } from '$lib/server/db/index.js';
 import { generateInviteCode } from '$lib/utils/invite-code.js';
 import type { Room } from '$lib/types/index.js';
 
+/** Duration after which a room is considered expired and eligible for deletion. */
+const ROOM_EXPIRY_INTERVAL = '6 hours';
+
 interface RoomRow {
 	id: string;
 	name: string;
@@ -38,7 +41,7 @@ export async function createRoom(name: string, creatorId: string): Promise<Room>
 			return toRoom(result.rows[0]);
 		} catch (e: unknown) {
 			const isUniqueViolation =
-				e instanceof Error && 'code' in e && (e as { code: string }).code === '23505';
+				e instanceof Error && 'code' in e && (e as { code?: string }).code === '23505';
 			if (!isUniqueViolation) throw e;
 			// Continue loop on invite code collision
 		}
@@ -78,6 +81,8 @@ export async function getRoomByInviteCode(inviteCode: string): Promise<Room | nu
 /**
  * Archive then hard-delete a single room.
  * Uses a single CTE so the archive and delete are atomic.
+ * On concurrent calls for the same room, the archive INSERT is idempotent
+ * (preserves the original archived_at timestamp).
  */
 export async function deleteRoom(roomId: string): Promise<void> {
 	const db = await getDb();
@@ -91,7 +96,7 @@ export async function deleteRoom(roomId: string): Promise<void> {
 		   FROM rooms r
 		   JOIN users u ON u.id = r.creator_id
 		   WHERE r.id = $1
-		   ON CONFLICT (id) DO NOTHING
+		   ON CONFLICT (id) DO UPDATE SET archived_at = archived_rooms.archived_at
 		 ),
 		 archive_participants AS (
 		   INSERT INTO archived_participants
@@ -99,7 +104,7 @@ export async function deleteRoom(roomId: string): Promise<void> {
 		   SELECT id, room_id, nickname, joined_at, last_seen_at, NOW()
 		   FROM participants
 		   WHERE room_id = $1
-		   ON CONFLICT (id) DO NOTHING
+		   ON CONFLICT (id) DO UPDATE SET archived_at = archived_participants.archived_at
 		 ),
 		 archive_messages AS (
 		   INSERT INTO archived_messages
@@ -108,7 +113,7 @@ export async function deleteRoom(roomId: string): Promise<void> {
 		   FROM messages m
 		   JOIN participants p ON p.id = m.participant_id
 		   WHERE m.room_id = $1
-		   ON CONFLICT (id) DO NOTHING
+		   ON CONFLICT (id) DO UPDATE SET archived_at = archived_messages.archived_at
 		 )
 		 DELETE FROM rooms WHERE id = $1`,
 		[roomId]
@@ -116,8 +121,9 @@ export async function deleteRoom(roomId: string): Promise<void> {
 }
 
 /**
- * Archive then hard-delete all rooms older than 6 hours.
+ * Archive then hard-delete all rooms older than ROOM_EXPIRY_INTERVAL.
  * Uses a single CTE so the archive and delete are atomic — no TOCTOU window.
+ * On concurrent calls, archive INSERTs are idempotent (preserve original timestamps).
  * Returns the IDs of deleted rooms.
  */
 export async function deleteExpiredRooms(): Promise<string[]> {
@@ -125,7 +131,7 @@ export async function deleteExpiredRooms(): Promise<string[]> {
 
 	const result = await db.query<{ id: string }>(
 		`WITH expired AS (
-		   SELECT id FROM rooms WHERE created_at < NOW() - INTERVAL '6 hours'
+		   SELECT id FROM rooms WHERE created_at < NOW() - INTERVAL '${ROOM_EXPIRY_INTERVAL}'
 		 ),
 		 archive_rooms AS (
 		   INSERT INTO archived_rooms
@@ -135,7 +141,7 @@ export async function deleteExpiredRooms(): Promise<string[]> {
 		   FROM rooms r
 		   JOIN users u ON u.id = r.creator_id
 		   WHERE r.id IN (SELECT id FROM expired)
-		   ON CONFLICT (id) DO NOTHING
+		   ON CONFLICT (id) DO UPDATE SET archived_at = archived_rooms.archived_at
 		 ),
 		 archive_participants AS (
 		   INSERT INTO archived_participants
@@ -143,7 +149,7 @@ export async function deleteExpiredRooms(): Promise<string[]> {
 		   SELECT id, room_id, nickname, joined_at, last_seen_at, NOW()
 		   FROM participants
 		   WHERE room_id IN (SELECT id FROM expired)
-		   ON CONFLICT (id) DO NOTHING
+		   ON CONFLICT (id) DO UPDATE SET archived_at = archived_participants.archived_at
 		 ),
 		 archive_messages AS (
 		   INSERT INTO archived_messages
@@ -152,7 +158,7 @@ export async function deleteExpiredRooms(): Promise<string[]> {
 		   FROM messages m
 		   JOIN participants p ON p.id = m.participant_id
 		   WHERE m.room_id IN (SELECT id FROM expired)
-		   ON CONFLICT (id) DO NOTHING
+		   ON CONFLICT (id) DO UPDATE SET archived_at = archived_messages.archived_at
 		 )
 		 DELETE FROM rooms WHERE id IN (SELECT id FROM expired)
 		 RETURNING id`
@@ -166,7 +172,7 @@ export async function countActiveRoomsByCreator(creatorId: string): Promise<numb
 	const result = await db.query<{ count: string }>(
 		`SELECT count(*)::text as count FROM rooms
 		 WHERE creator_id = $1 AND is_active = TRUE
-		 AND created_at > NOW() - INTERVAL '6 hours'`,
+		 AND created_at > NOW() - INTERVAL '${ROOM_EXPIRY_INTERVAL}'`,
 		[creatorId]
 	);
 	return parseInt(result.rows[0]?.count ?? '0', 10);


### PR DESCRIPTION
## Summary

- 6時間経過後に削除されるルーム・参加者・メッセージをアーカイブテーブルに保存
- `archived_rooms` / `archived_participants` / `archived_messages` テーブルを新規追加（マイグレーション 003）
- `deleteRoom()` / `deleteExpiredRooms()` を単一 CTE で原子的に実装（archive → delete）
- `getRoomByInviteCode()` に 6 時間期限フィルタを追加（期限切れルームへの参加を防止）

## Key design decisions

| 決定 | 理由 |
|------|------|
| 単一 CTE で archive + delete を実行 | PostgreSQL MVCC により一貫スナップショットで原子的に動作 |
| `ON CONFLICT (id) DO NOTHING` | 並行呼び出し時に 2 件目の DELETE が空振りするため、archive の重複挿入は発生しない |
| `LEFT JOIN users` + `COALESCE(u.email, '')` | creator アカウントが削除されていてもルームをアーカイブ可能に |
| `archived_messages` に `nickname` を非正規化保存 | 参照元 participants が削除後でもメッセージ表示が可能 |

## Test plan

- [ ] `npm run check` でエラーなし（0 errors, 2 pre-existing warnings）
- [ ] dev サーバー起動 → ブラウザで正常表示を確認
- [ ] DB に期限切れルームがある状態で admin ページにアクセス → `archived_*` テーブルにデータが入ること
- [ ] 期限切れルームの招待コードで参加しようとすると「ルームが見つからない」になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)